### PR TITLE
Add JSON-based sampler configuration

### DIFF
--- a/runner/mooglarunner/runner.go
+++ b/runner/mooglarunner/runner.go
@@ -619,14 +619,13 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		defer grammar.Free()
 	}
 
-	sampler := sample.NewSampler(
-		req.Options.Temperature,
-		req.Options.TopK,
-		req.Options.TopP,
-		req.Options.MinP,
-		req.Options.Seed,
-		grammar,
-	)
+	sampler := sample.NewSampler(sample.Config{
+		Temperature: req.Options.Temperature,
+		TopK:        req.Options.TopK,
+		TopP:        req.Options.TopP,
+		MinP:        req.Options.MinP,
+		Seed:        req.Options.Seed,
+	}, grammar)
 
 	seq, err := s.NewSequence(req.Prompt, req.Images, NewSequenceParams{
 		numPredict: req.Options.NumPredict,


### PR DESCRIPTION
## Summary
- allow `NewSampler` to take configuration via `Config`
- implement `Sampler.UnmarshalJSON`
- update runner and tests to create samplers from JSON

## Testing
- `go test ./sample` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ac969e8a083328e9697070ae0214f