### PR TITLE
Fix digest empty message

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -465,7 +465,7 @@ type downloadOpts struct {
 // downloadBlob downloads a blob from the registry and stores it in the blobs directory
 func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ error) {
 	if opts.digest == "" {
-		return false, fmt.Errorf(("%s: %s"), opts.mp.GetNamespaceRepository(), "digest is is empty")
+		return false, fmt.Errorf("%s: %s", opts.mp.GetNamespaceRepository(), "digest is empty")
 	}
 
 	fp, err := GetBlobsPath(opts.digest)


### PR DESCRIPTION
## Summary
- fix error message for empty digest error in `downloadBlob`

## Testing
- `go test ./...` *(fails: Forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ad51b83b48332958d72986e759bba