### PR TITLE
Remove debug log

### DIFF
--- a/app/lifecycle/updater.go
+++ b/app/lifecycle/updater.go
@@ -148,10 +148,9 @@ func DownloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
 	}
 	defer resp.Body.Close()
 	etag = strings.Trim(resp.Header.Get("etag"), "\"")
-	if etag == "" {
-		slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
-		etag = "_"
-	}
+       if etag == "" {
+               etag = "_"
+       }
 
 	stageFilename = filepath.Join(UpdateStageDir, etag, filename)
 


### PR DESCRIPTION
## Summary
- remove a duplicated `slog.Debug` for missing etag

## Testing
- `go test ./app/lifecycle -run TestRotateLogs -v` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b26229cc88332be2867bd494c4d53