### PR TITLE
Use GPU VRAM info in tests

### DIFF
--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -108,14 +108,9 @@ func TestIntegrationConcurrentPredict(t *testing.T) {
 
 // Stress the system if we know how much VRAM it has, and attempt to load more models than will fit
 func TestMultiModelStress(t *testing.T) {
-	s := os.Getenv("GOOBLA_MAX_VRAM") // TODO - discover actual VRAM
-	if s == "" {
-		t.Skip("GOOBLA_MAX_VRAM not specified, can't pick the right models for the stress test")
-	}
-
-	maxVram, err := strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		t.Fatal(err)
+	maxVram := availableVRAM()
+	if maxVram == 0 {
+		t.Skip("no GPU VRAM info available")
 	}
 	if maxVram < 2*format.GibiByte {
 		t.Skip("VRAM less than 2G, skipping model stress tests")

--- a/integration/hardware.go
+++ b/integration/hardware.go
@@ -1,0 +1,21 @@
+//go:build integration
+
+package integration
+
+import "github.com/goobla/goobla/discover"
+
+// availableVRAM returns the maximum total memory across all detected GPUs.
+// If no GPU is detected or discovery fails, zero is returned.
+func availableVRAM() uint64 {
+	gpus := discover.GetGPUInfo()
+	var max uint64
+	for _, g := range gpus {
+		if g.Library == "cpu" {
+			continue
+		}
+		if g.TotalMemory > max {
+			max = g.TotalMemory
+		}
+	}
+	return max
+}

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -349,14 +349,10 @@ func GenerateRequests() ([]api.GenerateRequest, [][]string) {
 }
 
 func skipUnderMinVRAM(t *testing.T, gb uint64) {
-	// TODO use info API in the future
-	if s := os.Getenv("GOOBLA_MAX_VRAM"); s != "" {
-		maxVram, err := strconv.ParseUint(s, 10, 64)
-		require.NoError(t, err)
-		// Don't hammer on small VRAM cards...
-		if maxVram < gb*format.GibiByte {
-			t.Skip("skipping with small VRAM to avoid timeouts")
-		}
+	maxVram := availableVRAM()
+	// Don't hammer on small VRAM cards...
+	if maxVram > 0 && maxVram < gb*format.GibiByte {
+		t.Skip("skipping with small VRAM to avoid timeouts")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `integration/hardware.go` with a helper to inspect GPUs via `discover`
- update `skipUnderMinVRAM` and `TestMultiModelStress` to rely on detected VRAM rather than `GOOBLA_MAX_VRAM`

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b566fc83329d741a230e1643ec