### PR TITLE
Add system info API and update tests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -428,3 +428,12 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 
 	return version.Version, nil
 }
+
+// Info returns hardware information from the Goobla server.
+func (c *Client) Info(ctx context.Context) (*SystemInfo, error) {
+	var info SystemInfo
+	if err := c.do(ctx, http.MethodGet, "/api/info", nil, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -480,6 +480,53 @@ type TokenResponse struct {
 	Token string `json:"token"`
 }
 
+// GpuInfo represents GPU hardware details returned by the /api/info endpoint.
+type GpuInfo struct {
+	TotalMemory          uint64      `json:"total_memory,omitempty"`
+	FreeMemory           uint64      `json:"free_memory,omitempty"`
+	FreeSwap             uint64      `json:"free_swap,omitempty"`
+	Library              string      `json:"library,omitempty"`
+	Variant              string      `json:"variant"`
+	DependencyPath       []string    `json:"lib_path,omitempty"`
+	EnvWorkarounds       [][2]string `json:"envs,omitempty"`
+	UnreliableFreeMemory bool        `json:"unreliable_free_memory"`
+	ID                   string      `json:"gpu_id"`
+	Name                 string      `json:"name"`
+	Compute              string      `json:"compute"`
+	DriverMajor          int         `json:"driver_major,omitempty"`
+	DriverMinor          int         `json:"driver_minor,omitempty"`
+}
+
+// CPU describes a single CPU package.
+type CPU struct {
+	ID                  string `json:"id"`
+	VendorID            string `json:"vendor_id"`
+	ModelName           string `json:"model_name"`
+	CoreCount           int    `json:"core_count"`
+	EfficiencyCoreCount int    `json:"efficiency_core_count"`
+	ThreadCount         int    `json:"thread_count"`
+}
+
+// CPUInfo contains CPU and memory information.
+type CPUInfo struct {
+	GpuInfo
+	CPUs []CPU `json:"cpus"`
+}
+
+// UnsupportedGPUInfo describes GPUs that were detected but cannot be used.
+type UnsupportedGPUInfo struct {
+	GpuInfo
+	Reason string `json:"reason"`
+}
+
+// SystemInfo is returned by the /api/info endpoint and describes system hardware.
+type SystemInfo struct {
+	System          CPUInfo              `json:"system"`
+	GPUs            []GpuInfo            `json:"gpus"`
+	UnsupportedGPUs []UnsupportedGPUInfo `json:"unsupported_gpus"`
+	DiscoveryErrors []string             `json:"discovery_errors"`
+}
+
 // GenerateResponse is the response passed into [GenerateResponseFunc].
 type GenerateResponse struct {
 	// Model is the model name that generated the response.

--- a/integration/model_arch_test.go
+++ b/integration/model_arch_test.go
@@ -58,15 +58,15 @@ func TestModelsGenerate(t *testing.T) {
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()
 
-	// TODO use info API eventually
+	info, err := client.Info(ctx)
+	require.NoError(t, err)
 	var maxVram uint64
-	var err error
-	if s := os.Getenv("GOOBLA_MAX_VRAM"); s != "" {
-		maxVram, err = strconv.ParseUint(s, 10, 64)
-		if err != nil {
-			t.Fatalf("invalid  GOOBLA_MAX_VRAM %v", err)
+	for _, g := range info.GPUs {
+		if g.TotalMemory > maxVram {
+			maxVram = g.TotalMemory
 		}
-	} else {
+	}
+	if maxVram == 0 {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 
@@ -111,15 +111,15 @@ func TestModelsEmbed(t *testing.T) {
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()
 
-	// TODO use info API eventually
+	info, err := client.Info(ctx)
+	require.NoError(t, err)
 	var maxVram uint64
-	var err error
-	if s := os.Getenv("GOOBLA_MAX_VRAM"); s != "" {
-		maxVram, err = strconv.ParseUint(s, 10, 64)
-		if err != nil {
-			t.Fatalf("invalid  GOOBLA_MAX_VRAM %v", err)
+	for _, g := range info.GPUs {
+		if g.TotalMemory > maxVram {
+			maxVram = g.TotalMemory
 		}
-	} else {
+	}
+	if maxVram == 0 {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -1209,6 +1209,7 @@ func (s *Server) GenerateRoutes(logger *slog.Logger, rc *goobla.Registry) (http.
 	r.POST("/api/copy", s.CopyHandler)
 
 	// Inference
+	r.GET("/api/info", s.InfoHandler)
 	r.GET("/api/ps", s.PsHandler)
 	r.POST("/api/generate", s.GenerateHandler)
 	r.POST("/api/chat", s.ChatHandler)
@@ -1396,6 +1397,10 @@ func streamResponse(c *gin.Context, ch chan any) {
 
 		return true
 	})
+}
+
+func (s *Server) InfoHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, discover.GetSystemInfo())
 }
 
 func (s *Server) PsHandler(c *gin.Context) {


### PR DESCRIPTION
## Summary
- add `/api/info` endpoint to report system hardware info
- expose `Info` method in `api.Client`
- define new hardware info types in `api` package
- update integration tests to query VRAM via the new API

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b612048332aef24e223465a7db