### PR TITLE
Improve template traversal

### DIFF
--- a/thinking/template_test.go
+++ b/thinking/template_test.go
@@ -119,6 +119,18 @@ For each function call, return a json object with function name and arguments wi
 			wantOpeningTag: "<think>",
 			wantClosingTag: "</think>",
 		},
+		{
+			desc: "pipeline reference ignored",
+			tmplString: `
+                        {{- range .Messages }}
+                                Opening
+                                {{ if .Thinking }}ignored{{ end }}
+                                Closing
+                        {{ end }}
+                `,
+			wantOpeningTag: "",
+			wantClosingTag: "",
+		},
 	}
 	for _, c := range cases {
 		tmpl := template.Must(template.New("test").Parse(c.tmplString))


### PR DESCRIPTION
## Summary
- differentiate pipeline nodes in template visitor
- ignore pipeline context when inferring thinking tags
- test that pipeline references are skipped

## Testing
- `go test ./thinking -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685c21b7089c8332b909fd1b2f2625db