### PR TITLE
Allocate vision tensors to GPU memory

### DIFF
--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -300,8 +300,11 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		case contains(t.Name, "cls", "output", "output_norm"):
 			createTensor(tensor{source: t}, output.bts, blocks)
 		case strings.HasPrefix(t.Name, "v.") || strings.HasPrefix(t.Name, "mm."):
-			// TODO: assign vision tensors to the gpu if possible
-			createTensor(tensor{source: t}, output.bts, blocks)
+			bts := output.bts
+			if len(gpuDeviceBufferTypes) > 0 {
+				bts = gpuDeviceBufferTypes[0].bts
+			}
+			createTensor(tensor{source: t}, bts, blocks)
 		case contains(t.Name, "rope_freqs", "rope_factors_long", "rope_factors_short"):
 			// these tensors should be repeated per layer
 			for i, layer := range layers {

--- a/ml/backend/ggml/ggml_gpu_test.go
+++ b/ml/backend/ggml/ggml_gpu_test.go
@@ -1,0 +1,52 @@
+package ggml
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/goobla/goobla/discover"
+	ggmlfs "github.com/goobla/goobla/fs/ggml"
+	"github.com/goobla/goobla/ml"
+)
+
+func TestVisionTensorGPUPlacement(t *testing.T) {
+	if len(discover.GetGPUInfo().ByLibrary()) <= 1 {
+		t.Skip("no GPU available")
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "model*.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	kv := ggmlfs.KV{
+		"general.architecture": "test",
+		"block_count":          uint32(0),
+	}
+
+	tensors := []*ggmlfs.Tensor{
+		{Name: "v.patch_embd.weight", Shape: []uint64{1, 1}, WriterTo: bytes.NewBuffer(make([]byte, 1))},
+	}
+
+	if err := ggmlfs.WriteGGUF(f, kv, tensors); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := New(f.Name(), ml.BackendParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mem := b.BackendMemory()
+	if len(mem.GPUs) == 0 {
+		t.Fatalf("no GPU memory entries")
+	}
+	if mem.GPUs[0].Weights[0].Size == 0 {
+		t.Fatalf("vision tensor not allocated on GPU")
+	}
+	if mem.CPU.Weights[0].Size != 0 {
+		t.Fatalf("vision tensor allocated on CPU")
+	}
+}


### PR DESCRIPTION
## Summary
- detect vision tensor names on load
- allocate vision tensors on GPU if available
- verify GPU placement with a new test

## Testing
- `go test ./...` *(fails: fetching dependencies from proxy.golang.org is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b7fc4c83329a3e2dbae447dc6b