### PR TITLE
Remove unused NUMA option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -397,7 +397,6 @@ curl http://localhost:11434/api/generate -d '{
     "frequency_penalty": 1.0,
     "penalize_newline": true,
     "stop": ["\n", "user:"],
-    "numa": false,
     "num_ctx": 1024,
     "num_batch": 2,
     "num_gpu": 1,

--- a/llm/server.go
+++ b/llm/server.go
@@ -249,8 +249,6 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		params = append(params, "--no-mmap")
 	}
 
-	// TODO - NUMA support currently doesn't work properly
-
 	params = append(params, "--parallel", strconv.Itoa(numParallel))
 
 	if estimate.TensorSplit != "" {


### PR DESCRIPTION
## Summary
- strip NUMA option from API documentation
- clean up server to drop TODO comment

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b8a5988332ad898a9f5e57a404