### PR TITLE
Return init error for encoder cache

### DIFF
--- a/kvcache/cache.go
+++ b/kvcache/cache.go
@@ -49,7 +49,9 @@ type Cache interface {
 	// maxSequences: The maximum number of sequences stored in the cache - across all batches
 	// capacity: The number of cache entries to store, per sequence
 	// maxBatch: The maximum number of tokens that can occur in a single batch
-	Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int)
+	//
+	// Returns an error if initialization fails.
+	Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) error
 
 	// Close closes the cache and frees resources associated with it
 	Close()

--- a/kvcache/causal.go
+++ b/kvcache/causal.go
@@ -114,7 +114,7 @@ func NewChunkedAttentionCache(chunkSize int32, shift shiftFn) *Causal {
 	}
 }
 
-func (c *Causal) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {
+func (c *Causal) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) error {
 	if c.config == nil {
 		var config ml.CacheConfig
 		if cc, ok := backend.(ml.BackendCacheConfig); ok {
@@ -147,6 +147,7 @@ func (c *Causal) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity
 	c.DType = dtype
 	c.cellRanges = make(map[int]cellRange)
 	c.backend = backend
+	return nil
 }
 
 func (c *Causal) SetConfig(config ml.CacheConfig) error {

--- a/kvcache/causal_test.go
+++ b/kvcache/causal_test.go
@@ -25,7 +25,9 @@ func TestStore(t *testing.T) {
 	cache := NewCausalCache(nil)
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -58,7 +60,9 @@ func TestSWA(t *testing.T) {
 	cache := NewSWACache(1, nil)
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -91,7 +95,9 @@ func TestChunkedAttention(t *testing.T) {
 	defer cache.Close()
 
 	var b testBackend
-	cache.Init(&b, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(&b, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	x := float32(math.Inf(-1))
 
@@ -149,7 +155,9 @@ func TestSequences(t *testing.T) {
 	cache := NewCausalCache(nil)
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -184,7 +192,9 @@ func TestRemove(t *testing.T) {
 	})
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -249,7 +259,9 @@ func TestDefrag(t *testing.T) {
 	})
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -297,7 +309,9 @@ func TestCopy(t *testing.T) {
 	cache := NewCausalCache(func(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) { return key, nil })
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	tests := []testCase{
 		{
@@ -372,7 +386,9 @@ func TestCanResume(t *testing.T) {
 	cache := NewSWACache(windowSize, nil)
 	defer cache.Close()
 
-	cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+	if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
 
 	context := backend.NewContext()
 	defer context.Close()
@@ -445,7 +461,9 @@ func TestSWARemoveWindow(t *testing.T) {
 		})
 		defer cache.Close()
 
-		cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+		if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
 
 		ctx := backend.NewContext()
 		defer ctx.Close()
@@ -485,7 +503,9 @@ func TestSWARemoveWindow(t *testing.T) {
 		})
 		defer cache.Close()
 
-		cache.Init(backend, ml.DTypeF16, 1, 16, 16)
+		if err := cache.Init(backend, ml.DTypeF16, 1, 16, 16); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
 
 		ctx := backend.NewContext()
 		defer ctx.Close()

--- a/kvcache/encoder.go
+++ b/kvcache/encoder.go
@@ -54,10 +54,11 @@ func NewEncoderCache() *EncoderCache {
 	}
 }
 
-func (c *EncoderCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {
+func (c *EncoderCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) error {
 	if err := c.SetBackend(backend, maxSequences); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func (c *EncoderCache) SetBackend(backend ml.Backend, maxSequences int) error {

--- a/kvcache/wrapper.go
+++ b/kvcache/wrapper.go
@@ -23,10 +23,13 @@ func NewWrapperCache(caches ...Cache) *WrapperCache {
 	}
 }
 
-func (c *WrapperCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {
+func (c *WrapperCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) error {
 	for _, cache := range c.caches {
-		cache.Init(backend, dtype, maxSequences, capacity, maxBatch)
+		if err := cache.Init(backend, dtype, maxSequences, capacity, maxBatch); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (c *WrapperCache) SetConfig(config ml.CacheConfig) error {

--- a/runner/gooblarunner/cache.go
+++ b/runner/gooblarunner/cache.go
@@ -46,7 +46,9 @@ func NewInputCache(model model.Model, kvCacheType string, kvSize int32, numSlots
 
 	cache := model.Config().Cache
 	if cache != nil {
-		cache.Init(model.Backend(), kvCacheTypeFromStr(kvCacheType), numSlots, int(numCtx), batchSize)
+		if err := cache.Init(model.Backend(), kvCacheTypeFromStr(kvCacheType), numSlots, int(numCtx), batchSize); err != nil {
+			return nil, err
+		}
 	}
 
 	return &InputCache{

--- a/runner/gooblarunner/cache_test.go
+++ b/runner/gooblarunner/cache_test.go
@@ -438,13 +438,15 @@ func (m *mockCache) Remove(seq int, beginIndex, endIndex int32) error {
 }
 
 // Stub implementations for other interface methods
-func (m *mockCache) SetLayer(layer int)                                                            {}
-func (m *mockCache) Get(ctx ml.Context) (ml.Tensor, ml.Tensor, ml.Tensor)                          { return nil, nil, nil }
-func (m *mockCache) Put(ctx ml.Context, key, value ml.Tensor)                                      {}
-func (m *mockCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) {}
-func (m *mockCache) Close()                                                                        {}
-func (m *mockCache) StartForward(ctx ml.Context, batch input.Batch, reserve bool) error            { return nil }
-func (m *mockCache) CopyPrefix(srcSeq, dstSeq int, len int32)                                      {}
+func (m *mockCache) SetLayer(layer int)                                   {}
+func (m *mockCache) Get(ctx ml.Context) (ml.Tensor, ml.Tensor, ml.Tensor) { return nil, nil, nil }
+func (m *mockCache) Put(ctx ml.Context, key, value ml.Tensor)             {}
+func (m *mockCache) Init(backend ml.Backend, dtype ml.DType, maxSequences, capacity, maxBatch int) error {
+	return nil
+}
+func (m *mockCache) Close()                                                             {}
+func (m *mockCache) StartForward(ctx ml.Context, batch input.Batch, reserve bool) error { return nil }
+func (m *mockCache) CopyPrefix(srcSeq, dstSeq int, len int32)                           {}
 func (m *mockCache) SetConfig(ml.CacheConfig) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
- have caches return errors when init fails
- handle init errors in callers like NewInputCache
- update mock cache and causal tests for new signature

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c31cab1b4833293fbc1d3fce559c6