### PR TITLE
Add PCI scanning and improve GPU detection

### DIFF
--- a/discover/amd_linux.go
+++ b/discover/amd_linux.go
@@ -291,9 +291,9 @@ func AMDGetGPUInfo() ([]RocmGPUInfo, error) {
 		}
 
 		// iGPU detection, remove this check once we can support an iGPU variant of the rocm library
-		if totalMemory < IGPUMemLimit {
+		if isIntegratedGPU(name) {
 			reason := "unsupported Radeon iGPU detected skipping"
-			slog.Info(reason, "id", gpuID, "total", format.HumanBytes2(totalMemory))
+			slog.Info(reason, "id", gpuInfo.ID, "name", name)
 			unsupportedGPUs = append(unsupportedGPUs, UnsupportedGPUInfo{
 				GpuInfo: gpuInfo.GpuInfo,
 				Reason:  reason,

--- a/discover/amd_windows.go
+++ b/discover/amd_windows.go
@@ -122,9 +122,9 @@ func AMDGetGPUInfo() ([]RocmGPUInfo, error) {
 		}
 
 		// iGPU detection, remove this check once we can support an iGPU variant of the rocm library
-		if strings.EqualFold(name, iGPUName) || totalMemory < IGPUMemLimit {
+		if strings.EqualFold(name, iGPUName) || isIntegratedGPU(name) {
 			reason := "unsupported Radeon iGPU detected skipping"
-			slog.Info(reason, "id", gpuInfo.ID, "total", format.HumanBytes2(totalMemory))
+			slog.Info(reason, "id", gpuInfo.ID, "name", name)
 			unsupportedGPUs = append(unsupportedGPUs, UnsupportedGPUInfo{
 				GpuInfo: gpuInfo.GpuInfo,
 				Reason:  reason,


### PR DESCRIPTION
## Summary
- detect GPUs with lspci/wmic when libraries fail
- improve integrated GPU detection based on GPU name
- ensure discovered GPUs have matching runner directories
- add unit tests for PCI parsing, iGPU detection and runner availability

## Testing
- `go test ./...` *(fails: downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c31cb87208332b7fedc64fe6be274