### PR TITLE
Improve macOS VRAM reporting

### DIFF
--- a/discover/gpu_info_darwin.h
+++ b/discover/gpu_info_darwin.h
@@ -3,3 +3,7 @@
 uint64_t getRecommendedMaxVRAM();
 uint64_t getPhysicalMemory();
 uint64_t getFreeMemory();
+// getCurrentAllocatedVRAM returns the number of bytes of VRAM currently
+// allocated by the system's default Metal device. Returns 0 on platforms that
+// do not support querying this value.
+uint64_t getCurrentAllocatedVRAM();

--- a/discover/gpu_info_darwin.m
+++ b/discover/gpu_info_darwin.m
@@ -9,6 +9,18 @@ uint64_t getRecommendedMaxVRAM() {
   return result;
 }
 
+uint64_t getCurrentAllocatedVRAM() {
+  id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+  uint64_t result = 0;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
+  if ([device respondsToSelector:@selector(currentAllocatedSize)]) {
+    result = device.currentAllocatedSize;
+  }
+#endif
+  CFRelease(device);
+  return result;
+}
+
 // getPhysicalMemory returns the total physical memory in bytes
 uint64_t getPhysicalMemory() {
   return [NSProcessInfo processInfo].physicalMemory;


### PR DESCRIPTION
## Summary
- use Metal API to track current VRAM allocations on macOS
- update comments and header for new function

## Testing
- `go generate ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c31cbfaf08332b0b851e97acfbd9b