### PR TITLE
Add GOOBLA_CONFIG env var

### DIFF
--- a/app/store/store_darwin.go
+++ b/app/store/store_darwin.go
@@ -6,7 +6,9 @@ import (
 )
 
 func getStorePath() string {
-	// TODO - system wide location?
+	if s := os.Getenv("GOOBLA_CONFIG"); s != "" {
+		return s
+	}
 
 	home := os.Getenv("HOME")
 	return filepath.Join(home, "Library", "Application Support", "Goobla", "config.json")

--- a/app/store/store_linux.go
+++ b/app/store/store_linux.go
@@ -6,8 +6,11 @@ import (
 )
 
 func getStorePath() string {
+	if s := os.Getenv("GOOBLA_CONFIG"); s != "" {
+		return s
+	}
+
 	if os.Geteuid() == 0 {
-		// TODO where should we store this on linux for system-wide operation?
 		return "/etc/goobla/config.json"
 	}
 

--- a/app/store/store_windows.go
+++ b/app/store/store_windows.go
@@ -6,6 +6,10 @@ import (
 )
 
 func getStorePath() string {
+	if s := os.Getenv("GOOBLA_CONFIG"); s != "" {
+		return s
+	}
+
 	localAppData := os.Getenv("LOCALAPPDATA")
 	return filepath.Join(localAppData, "Goobla", "config.json")
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -158,6 +158,14 @@ Goobla binds 127.0.0.1 port 11434 by default. Change the bind address with the `
 
 Refer to the section [above](#how-do-i-configure-goobla-server) for how to set environment variables on your platform.
 
+## Where is the configuration stored?
+
+- macOS: `~/Library/Application Support/Goobla/config.json`
+- Linux: `~/.goobla/config.json` (root: `/etc/goobla/config.json`)
+- Windows: `%LOCALAPPDATA%\Goobla\config.json`
+
+Set the `GOOBLA_CONFIG` environment variable to override the location.
+
 ## How can I use Goobla with a proxy server?
 
 Goobla runs an HTTP server and can be exposed using a proxy server such as Nginx. To do so, configure the proxy to forward requests and optionally set required headers (if not exposing Goobla on the network). For example, with Nginx:

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -269,6 +269,7 @@ func AsMap() map[string]EnvVar {
 			m, _ := Models()
 			return EnvVar{"GOOBLA_MODELS", m, "The path to the models directory"}
 		}(),
+		"GOOBLA_CONFIG":          {"GOOBLA_CONFIG", String("GOOBLA_CONFIG")(), "Path to the configuration file"},
 		"GOOBLA_NOHISTORY":       {"GOOBLA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"GOOBLA_NOPRUNE":         {"GOOBLA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"GOOBLA_NUM_PARALLEL":    {"GOOBLA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},


### PR DESCRIPTION
## Summary
- add GOOBLA_CONFIG entry in envconfig
- allow overriding store path using GOOBLA_CONFIG
- document config storage and env var in FAQ

## Testing
- `go test ./...` *(fails: forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_686439fbe3048332b5a9678f25bfb63f