### PR TITLE
Fix spinner resource leak

### DIFF
--- a/progress/spinner_test.go
+++ b/progress/spinner_test.go
@@ -1,0 +1,28 @@
+package progress
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSpinnerStartStop(t *testing.T) {
+	s := NewSpinner("test")
+	defer s.Stop()
+	time.Sleep(150 * time.Millisecond)
+
+	s.mu.Lock()
+	val1 := s.value
+	s.mu.Unlock()
+	if val1 == 0 {
+		t.Fatalf("spinner did not advance")
+	}
+
+	s.Stop()
+	val2 := s.value
+	time.Sleep(150 * time.Millisecond)
+	s.mu.Lock()
+	if s.value != val2 {
+		t.Fatalf("spinner advanced after stop")
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- prevent ticker leaks in the progress spinner by guarding access with a mutex and stopping the ticker
- add regression test for spinner behaviour

## Testing
- `go test ./progress -run TestSpinnerStartStop -count=1` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68643be4a5c483328d3a233fb6f33616