### PR TITLE
Remove leftover intermediate blob cache

### DIFF
--- a/server/model.go
+++ b/server/model.go
@@ -17,8 +17,6 @@ import (
 	"github.com/goobla/goobla/types/model"
 )
 
-var intermediateBlobs map[string]string = make(map[string]string)
-
 type layerGGML struct {
 	Layer
 	*ggml.GGML

--- a/server/routes.go
+++ b/server/routes.go
@@ -1016,24 +1016,6 @@ func (s *Server) HeadBlobHandler(c *gin.Context) {
 }
 
 func (s *Server) CreateBlobHandler(c *gin.Context) {
-	if ib, ok := intermediateBlobs[c.Param("digest")]; ok {
-		p, err := GetBlobsPath(ib)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-
-		if _, err := os.Stat(p); errors.Is(err, os.ErrNotExist) {
-			slog.Info("evicting intermediate blob which no longer exists", "digest", ib)
-			delete(intermediateBlobs, c.Param("digest"))
-		} else if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		} else {
-			c.Status(http.StatusOK)
-			return
-		}
-	}
 
 	path, err := GetBlobsPath(c.Param("digest"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- clean up leftover map for intermediate blob handling
- simplify blob creation handler logic

## Testing
- `go test ./...` *(fails: could not fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_686440ffae0c83329d396d1ec5f6d39d