### PR TITLE
Introduce request timeouts

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -67,7 +67,7 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (st
 
 	headers.Add("Authorization", signature)
 
-	response, err := makeRequest(ctx, http.MethodGet, redirectURL, headers, nil, &registryOptions{})
+	response, err := makeRequest(ctx, http.MethodGet, redirectURL, headers, nil, &registryOptions{Timeout: defaultHTTPTimeout})
 	if err != nil {
 		return "", err
 	}

--- a/server/model.go
+++ b/server/model.go
@@ -26,7 +26,7 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 	m, err := ParseNamedManifest(name)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		if err := PullModel(ctx, name.String(), &registryOptions{}, fn); err != nil {
+		if err := PullModel(ctx, name.String(), &registryOptions{Timeout: defaultHTTPTimeout}, fn); err != nil {
 			return nil, err
 		}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -605,6 +605,7 @@ func (s *Server) PullHandler(c *gin.Context) {
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
+			Timeout:  defaultHTTPTimeout,
 		}
 
 		ctx, cancel := context.WithCancel(c.Request.Context())
@@ -654,6 +655,7 @@ func (s *Server) PushHandler(c *gin.Context) {
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
+			Timeout:  defaultHTTPTimeout,
 		}
 
 		ctx, cancel := context.WithCancel(c.Request.Context())

--- a/server/upload.go
+++ b/server/upload.go
@@ -258,7 +258,7 @@ func (b *blobUpload) uploadPart(ctx context.Context, method string, requestURL *
 
 		// retry uploading to the redirect URL
 		for try := range maxRetries {
-			err = b.uploadPart(ctx, http.MethodPut, redirectURL, part, &registryOptions{})
+			err = b.uploadPart(ctx, http.MethodPut, redirectURL, part, &registryOptions{Timeout: opts.Timeout})
 			switch {
 			case errors.Is(err, context.Canceled):
 				return err


### PR DESCRIPTION
## Summary
- add `Timeout` to registry options to prevent hanging requests
- use `defaultHTTPTimeout` across API handlers

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686443f74fe083328faaabdbbeb80d9d