### PR TITLE
Improve keypair security

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1338,7 +1338,8 @@ func initializeKeypair() error {
 			return err
 		}
 
-		if err := os.MkdirAll(filepath.Dir(privKeyPath), 0o755); err != nil {
+		dir := filepath.Dir(privKeyPath)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("could not create directory %w", err)
 		}
 

--- a/cmd/keypair_test.go
+++ b/cmd/keypair_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitializeKeypairCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	if err := initializeKeypair(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	priv := filepath.Join(dir, ".goobla", "id_ed25519")
+	pub := filepath.Join(dir, ".goobla", "id_ed25519.pub")
+
+	if _, err := os.Stat(priv); err != nil {
+		t.Fatalf("private key not created: %v", err)
+	}
+	if _, err := os.Stat(pub); err != nil {
+		t.Fatalf("public key not created: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Dir(priv))
+	if err != nil {
+		t.Fatalf("dir stat error: %v", err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("expected dir perm 0700, got %v", info.Mode().Perm())
+	}
+
+	// second call should not error
+	if err := initializeKeypair(); err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- tighten permissions of the keypair directory
- add regression test for keypair creation

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686446212bfc833285a4fa08e7500916