### PR TITLE
Add registry timeout env var and tests

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -135,6 +135,25 @@ func LoadTimeout() (loadTimeout time.Duration) {
 	return loadTimeout
 }
 
+// RegistryTimeout returns the HTTP read timeout used for registry
+// operations. RegistryTimeout can be configured via the
+// GOOBLA_REGISTRY_TIMEOUT environment variable. Zero or negative values are
+// treated as infinite. Default is 30 seconds.
+func RegistryTimeout() (d time.Duration) {
+	d = 30 * time.Second
+	if s := Var("GOOBLA_REGISTRY_TIMEOUT"); s != "" {
+		if v, err := time.ParseDuration(s); err == nil {
+			d = v
+		} else if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			d = time.Duration(n) * time.Second
+		}
+	}
+	if d <= 0 {
+		return time.Duration(math.MaxInt64)
+	}
+	return d
+}
+
 func Bool(k string) func() bool {
 	return func() bool {
 		if s := Var(k); s != "" {
@@ -263,6 +282,7 @@ func AsMap() map[string]EnvVar {
 		"GOOBLA_KEEP_ALIVE":        {"GOOBLA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"GOOBLA_LLM_LIBRARY":       {"GOOBLA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"GOOBLA_LOAD_TIMEOUT":      {"GOOBLA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"GOOBLA_REGISTRY_TIMEOUT":  {"GOOBLA_REGISTRY_TIMEOUT", RegistryTimeout(), "HTTP read timeout for registry operations (default \"30s\")"},
 		"GOOBLA_MAX_LOADED_MODELS": {"GOOBLA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"GOOBLA_MAX_QUEUE":         {"GOOBLA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
 		func() EnvVar {

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -259,6 +259,27 @@ func TestLoadTimeout(t *testing.T) {
 	}
 }
 
+func TestRegistryTimeout(t *testing.T) {
+	defaultTimeout := 30 * time.Second
+	cases := map[string]time.Duration{
+		"":    defaultTimeout,
+		"1s":  time.Second,
+		"60":  60 * time.Second,
+		"0":   time.Duration(math.MaxInt64),
+		"-1":  time.Duration(math.MaxInt64),
+		"bad": defaultTimeout,
+	}
+
+	for val, expect := range cases {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("GOOBLA_REGISTRY_TIMEOUT", val)
+			if got := RegistryTimeout(); got != expect {
+				t.Errorf("%s: expected %s, got %s", val, expect, got)
+			}
+		})
+	}
+}
+
 func TestVar(t *testing.T) {
 	cases := map[string]string{
 		"value":       "value",

--- a/server/internal/client/goobla/chunk_test.go
+++ b/server/internal/client/goobla/chunk_test.go
@@ -1,0 +1,33 @@
+package goobla
+
+import (
+	"testing"
+
+	"github.com/goobla/goobla/server/internal/cache/blob"
+)
+
+func TestParseChunk(t *testing.T) {
+	tests := []struct {
+		in  string
+		out blob.Chunk
+		ok  bool
+	}{
+		{"0-1", blob.Chunk{Start: 0, End: 1}, true},
+		{"5-5", blob.Chunk{Start: 5, End: 5}, true},
+		{"1-0", blob.Chunk{}, false},
+		{"a-b", blob.Chunk{}, false},
+		{"1-b", blob.Chunk{}, false},
+		{"1", blob.Chunk{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			c, err := parseChunk(tt.in)
+			if (err == nil) != tt.ok {
+				t.Fatalf("err=%v ok=%v", err, tt.ok)
+			}
+			if tt.ok && (c != tt.out) {
+				t.Fatalf("got %+v want %+v", c, tt.out)
+			}
+		})
+	}
+}

--- a/server/internal/client/goobla/registry.go
+++ b/server/internal/client/goobla/registry.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/goobla/goobla/envconfig"
 	"github.com/goobla/goobla/server/internal/cache/blob"
 	"github.com/goobla/goobla/server/internal/internal/names"
 
@@ -272,7 +273,7 @@ func DefaultRegistry() (*Registry, error) {
 	}
 
 	var rc Registry
-	rc.ReadTimeout = 30 * time.Second
+	rc.ReadTimeout = envconfig.RegistryTimeout()
 	rc.UserAgent = UserAgent()
 	rc.Key, err = ssh.ParseRawPrivateKey(keyPEM)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add GOOBLA_REGISTRY_TIMEOUT env var and helper
- hook into DefaultRegistry for configurable registry timeout
- test RegistryTimeout parsing
- add parseChunk regression tests

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866a72c7b648332a0a93e043fc908cc