### PR TITLE
Improve config path handling

### DIFF
--- a/app/store/store_darwin.go
+++ b/app/store/store_darwin.go
@@ -3,6 +3,8 @@ package store
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/goobla/goobla/envconfig"
 )
 
 func getStorePath() string {
@@ -10,6 +12,6 @@ func getStorePath() string {
 		return s
 	}
 
-	home := os.Getenv("HOME")
-	return filepath.Join(home, "Library", "Application Support", "Goobla", "config.json")
+	dir := envconfig.ConfigDir()
+	return filepath.Join(dir, "config.json")
 }

--- a/app/store/store_linux.go
+++ b/app/store/store_linux.go
@@ -3,6 +3,8 @@ package store
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/goobla/goobla/envconfig"
 )
 
 func getStorePath() string {
@@ -14,6 +16,6 @@ func getStorePath() string {
 		return "/etc/goobla/config.json"
 	}
 
-	home := os.Getenv("HOME")
-	return filepath.Join(home, ".goobla", "config.json")
+	dir := envconfig.ConfigDir()
+	return filepath.Join(dir, "config.json")
 }

--- a/app/store/store_windows.go
+++ b/app/store/store_windows.go
@@ -3,6 +3,8 @@ package store
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/goobla/goobla/envconfig"
 )
 
 func getStorePath() string {
@@ -10,6 +12,6 @@ func getStorePath() string {
 		return s
 	}
 
-	localAppData := os.Getenv("LOCALAPPDATA")
-	return filepath.Join(localAppData, "Goobla", "config.json")
+	dir := envconfig.ConfigDir()
+	return filepath.Join(dir, "config.json")
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1317,16 +1317,11 @@ func RunServer(_ *cobra.Command, _ []string) error {
 }
 
 func initializeKeypair() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
+	dir := envconfig.ConfigDir()
+	privKeyPath := filepath.Join(dir, "id_ed25519")
+	pubKeyPath := filepath.Join(dir, "id_ed25519.pub")
 
-	privKeyPath := filepath.Join(home, ".goobla", "id_ed25519")
-	pubKeyPath := filepath.Join(home, ".goobla", "id_ed25519.pub")
-
-	_, err = os.Stat(privKeyPath)
-	if os.IsNotExist(err) {
+	if _, err := os.Stat(privKeyPath); os.IsNotExist(err) {
 		fmt.Printf("Couldn't find '%s'. Generating new private key.\n", privKeyPath)
 		cryptoPublicKey, cryptoPrivateKey, err := ed25519.GenerateKey(rand.Reader)
 		if err != nil {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -161,10 +161,11 @@ Refer to the section [above](#how-do-i-configure-goobla-server) for how to set e
 ## Where is the configuration stored?
 
 - macOS: `~/Library/Application Support/Goobla/config.json`
-- Linux: `~/.goobla/config.json` (root: `/etc/goobla/config.json`)
-- Windows: `%LOCALAPPDATA%\Goobla\config.json`
+- Linux: `~/.config/goobla/config.json` (root: `/etc/goobla/config.json`)
+- Windows: `%AppData%\Goobla\config.json`
 
-Set the `GOOBLA_CONFIG` environment variable to override the location.
+Set the `GOOBLA_CONFIG` environment variable to override the location. The base
+directory can be changed with `GOOBLA_CONFIG_DIR`.
 
 ## How can I use Goobla with a proxy server?
 
@@ -213,8 +214,8 @@ Refer to the section [above](#how-do-i-configure-goobla-server) for how to set e
 ## Where are models stored?
 
 - macOS: `~/.goobla/models`
-- Linux: `/usr/share/goobla/.goobla/models`
-- Windows: `C:\Users\%username%\.goobla\models`
+- Linux: `~/.config/goobla/models`
+- Windows: `%AppData%\Goobla\models`
 
 ### How do I set them to a different location?
 

--- a/readline/history.go
+++ b/readline/history.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/emirpasic/gods/v2/lists/arraylist"
+	"github.com/goobla/goobla/envconfig"
 )
 
 type History struct {
@@ -38,12 +39,7 @@ func NewHistory() (*History, error) {
 }
 
 func (h *History) Init() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	path := filepath.Join(home, ".goobla", "history")
+	path := filepath.Join(envconfig.ConfigDir(), "history")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- centralize config directory logic in envconfig
- use config directory for private keys and history file
- adjust store paths to use new ConfigDir
- document config path changes

## Testing
- `go fmt ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866a8e72a808332acdbeeabc90e067a