### PR TITLE
Disable pprof by default

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -6,7 +6,7 @@ This document outlines observations and improvement suggestions based on a quick
 
 ### Profiling Endpoints Enabled by Default
 
-The server exposes Go's `pprof` handlers by default when `GOOBLA_PPROF` is unset or set to `on`. This happens in the server startup logic:
+The server previously exposed Go's `pprof` handlers by default when `GOOBLA_PPROF` was unset or set to `on`. This has since been changed so profiling is disabled unless explicitly enabled. The original code looked like this:
 
 ```go
 pprofAddr := strings.ToLower(envconfig.PprofAddr())
@@ -31,15 +31,18 @@ PprofAddr = String("GOOBLA_PPROF")
 
 _Source: `envconfig/config.go` lines 189‑191_
 
-Documentation reiterates that pprof is enabled by default:
+Documentation at the time reiterated that pprof was enabled by default:
 
-```
+```md
 ## Profiling
 By default the server exposes Go's pprof handlers on the main port. Set the
 environment variable `GOOBLA_PPROF` to `off` to disable these endpoints or
 specify a host and port such as `127.0.0.1:6060` to run pprof on a separate
 port.
 ```
+
+Current behavior disables pprof unless `GOOBLA_PPROF` is set to `on` or a custom
+address.
 
 _Source: `docs/development.md` lines 160‑166_
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,7 +160,7 @@ If the libraries are not found, Goobla will not run with any acceleration librar
 
 ## Profiling
 
-By default the server exposes Go's pprof handlers on the main port. Set the
-environment variable `GOOBLA_PPROF` to `off` to disable these endpoints or
+By default the server does **not** expose Go's pprof handlers. Set the
+environment variable `GOOBLA_PPROF` to `on` to enable them on the main port or
 specify a host and port such as `127.0.0.1:6060` to run pprof on a separate
 port.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -260,8 +260,9 @@ var (
 	ContextLength = Uint("GOOBLA_CONTEXT_LENGTH", 4096)
 	// Auth enables authentication between the Goobla client and server
 	UseAuth = Bool("GOOBLA_AUTH")
-	// PprofAddr configures the pprof server address. Set to "off" to disable
-	// pprof or specify a custom address (e.g. 127.0.0.1:6060).
+	// PprofAddr configures the pprof server address. Leave empty or set to "off"
+	// to disable profiling, set to "on" to run pprof on the main port, or specify
+	// a custom address (e.g. 127.0.0.1:6060) to run pprof on a separate port.
 	PprofAddr = String("GOOBLA_PPROF")
 )
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -1281,12 +1281,12 @@ func Serve(ln net.Listener) error {
 	pprofAddr := strings.ToLower(envconfig.PprofAddr())
 	var srvr *http.Server
 	switch pprofAddr {
-	case "", "on":
+	case "on":
 		// Use DefaultServeMux so we get net/http/pprof handlers on the
 		// main server.
 		http.Handle("/", h)
 		srvr = newHTTPServer(nil)
-	case "off", "false", "0":
+	case "", "off", "false", "0":
 		srvr = newHTTPServer(h)
 	default:
 		// Serve application routes on the main server and start pprof on


### PR DESCRIPTION
## Summary
- turn off pprof handlers unless explicitly enabled
- clarify GOOBLA_PPROF behaviour in docs and comments
- update audit notes to mention the change

## Testing
- `go vet ./...` *(fails: fetching modules requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_6866b2d1e73c8332893b55b38ff8aca6