### PR TITLE
Add best practices doc and fix envconfig map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,5 @@
 
 * [Troubleshooting Guide](./troubleshooting.md)
 * [FAQ](./faq.md)
+* [Best Practices](./best-practices.md)
 * [Development guide](./development.md)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,28 @@
+# Best Practices
+
+This document lists recommended practices when running or modifying Goobla.
+
+## Security
+
+- **Disable profiling** unless explicitly required. Set `GOOBLA_PPROF=off` in production and run pprof on a separate port when needed.
+- **Protect registry and pull/push endpoints** behind authentication and TLS. Never expose them directly to the public Internet.
+- **Validate configuration values** at startup and fail fast on invalid settings.
+- **Avoid committing credentials**. Example keys in documentation are placeholders and should not be reused.
+
+## Performance and Reliability
+
+- Use the built‑in prompt cache when serving multiple users (`GOOBLA_MULTIUSER_CACHE=1`).
+- Run integration tests and linters (`go vet`, `staticcheck`) before deploying changes.
+- Monitor GPU and memory usage to size hardware appropriately.
+
+## Logging
+
+- Prefer structured logging through `logutil.NewLogger`.
+- Include context such as request IDs when logging errors.
+
+## Code Quality
+
+- Write concurrency tests for packages that interact with the cache or scheduler.
+- Document public functions and keep the `docs/` folder up to date with code changes.
+
+Following these guidelines helps keep deployments secure and maintainable.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -358,10 +358,10 @@ func AsMap() map[string]EnvVar {
 		"GOOBLA_SHUTDOWN_TIMEOUT":   {"GOOBLA_SHUTDOWN_TIMEOUT", ShutdownTimeout(), "HTTP server shutdown timeout (default \"5s\")"},
 		"GOOBLA_MAX_LOADED_MODELS":  {"GOOBLA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"GOOBLA_MAX_QUEUE":          {"GOOBLA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
-		func() EnvVar {
-			m, _ := Models()
-			return EnvVar{"GOOBLA_MODELS", m, "The path to the models directory"}
-		}(),
+               "GOOBLA_MODELS": func() EnvVar {
+                       m, _ := Models()
+                       return EnvVar{"GOOBLA_MODELS", m, "The path to the models directory"}
+               }(),
 		"GOOBLA_CONFIG":          {"GOOBLA_CONFIG", String("GOOBLA_CONFIG")(), "Path to the configuration file"},
 		"GOOBLA_CONFIG_DIR":      {"GOOBLA_CONFIG_DIR", configDir(), "Base directory for configuration and models"},
 		"GOOBLA_NOHISTORY":       {"GOOBLA_NOHISTORY", NoHistory(), "Do not preserve readline history"},


### PR DESCRIPTION
## Summary
- fix `AsMap` in envconfig so `GOOBLA_MODELS` key is declared explicitly
- document best practices for running and developing Goobla
- link new doc from docs index

## Testing
- `go test ./...` *(fails: forbidden module downloads)*
- `go vet ./...` *(fails: forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf5434a08332bdc1bec4922f0c27