### PR TITLE
Improve env parsing and thinking warnings

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -78,7 +78,11 @@ func Host() *url.URL {
 // AllowedOrigins returns a list of allowed origins. AllowedOrigins can be configured via the GOOBLA_ORIGINS environment variable.
 func AllowedOrigins() (origins []string) {
 	if s := Var("GOOBLA_ORIGINS"); s != "" {
-		origins = strings.Split(s, ",")
+		for _, o := range strings.Split(s, ",") {
+			if trimmed := strings.TrimSpace(o); trimmed != "" {
+				origins = append(origins, trimmed)
+			}
+		}
 	}
 
 	for _, origin := range []string{"localhost", "127.0.0.1", "0.0.0.0"} {
@@ -358,10 +362,10 @@ func AsMap() map[string]EnvVar {
 		"GOOBLA_SHUTDOWN_TIMEOUT":   {"GOOBLA_SHUTDOWN_TIMEOUT", ShutdownTimeout(), "HTTP server shutdown timeout (default \"5s\")"},
 		"GOOBLA_MAX_LOADED_MODELS":  {"GOOBLA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"GOOBLA_MAX_QUEUE":          {"GOOBLA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
-               "GOOBLA_MODELS": func() EnvVar {
-                       m, _ := Models()
-                       return EnvVar{"GOOBLA_MODELS", m, "The path to the models directory"}
-               }(),
+		"GOOBLA_MODELS": func() EnvVar {
+			m, _ := Models()
+			return EnvVar{"GOOBLA_MODELS", m, "The path to the models directory"}
+		}(),
 		"GOOBLA_CONFIG":          {"GOOBLA_CONFIG", String("GOOBLA_CONFIG")(), "Path to the configuration file"},
 		"GOOBLA_CONFIG_DIR":      {"GOOBLA_CONFIG_DIR", configDir(), "Base directory for configuration and models"},
 		"GOOBLA_NOHISTORY":       {"GOOBLA_NOHISTORY", NoHistory(), "Do not preserve readline history"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -135,6 +135,27 @@ func TestOrigins(t *testing.T) {
 			"vscode-webview://*",
 			"vscode-file://*",
 		}},
+		{" http://totally.safe , https://definitely.legit ", []string{
+			"http://totally.safe",
+			"https://definitely.legit",
+			"http://localhost",
+			"https://localhost",
+			"http://localhost:*",
+			"https://localhost:*",
+			"http://127.0.0.1",
+			"https://127.0.0.1",
+			"http://127.0.0.1:*",
+			"https://127.0.0.1:*",
+			"http://0.0.0.0",
+			"https://0.0.0.0",
+			"http://0.0.0.0:*",
+			"https://0.0.0.0:*",
+			"app://*",
+			"file://*",
+			"tauri://*",
+			"vscode-webview://*",
+			"vscode-file://*",
+		}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.value, func(t *testing.T) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -214,7 +214,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	if req.Think != nil && !*req.Think && !slices.Contains(m.Capabilities(), model.CapabilityThinking) {
-		slog.Warn("model does not support thinking output", "model", req.Model)
+		msg := "model does not support thinking output"
+		if m.Config.ModelFamily == "qwen3" || model.ParseName(m.Name).Model == "deepseek-r1" {
+			msg += "; pull the model again to get the latest version with full thinking support"
+		}
+		slog.Warn(msg, "model", req.Model)
 	}
 
 	checkpointLoaded := time.Now()


### PR DESCRIPTION
## Summary
- trim spaces from GOOBLA_ORIGINS parsing
- warn when models lacking thinking support are used with `think` disabled
- test trimming behavior in AllowedOrigins

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866c313afd08332a0cf0d7753558503