### PR TITLE
Add TLS options and env validation

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -5,7 +5,7 @@ This document lists recommended practices when running or modifying Goobla.
 ## Security
 
 - **Disable profiling** unless explicitly required. Set `GOOBLA_PPROF=off` in production and run pprof on a separate port when needed.
-- **Protect registry and pull/push endpoints** behind authentication and TLS. Never expose them directly to the public Internet.
+- **Protect registry and pull/push endpoints** behind authentication and TLS. Set `GOOBLA_TLS_CERT` and `GOOBLA_TLS_KEY` to serve HTTPS and never expose these endpoints directly to the public Internet.
 - **Validate configuration values** at startup and fail fast on invalid settings.
 - **Avoid committing credentials**. Example keys in documentation are placeholders and should not be reused.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,6 +161,6 @@ If the libraries are not found, Goobla will not run with any acceleration librar
 ## Profiling
 
 By default the server does **not** expose Go's pprof handlers. Set the
-environment variable `GOOBLA_PPROF` to `on` to enable them on the main port or
+environment variable `GOOBLA_PPROF` to `on` to enable them on the main port, or
 specify a host and port such as `127.0.0.1:6060` to run pprof on a separate
-port.
+port. Leave the variable unset or set to `off` in production.

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -106,7 +106,7 @@ const openai = new OpenAI({
   baseURL: 'http://localhost:11434/v1/',
 
   // required but ignored
-  apiKey: 'goobla',
+  apiKey: 'goobla', // placeholder key, do not use real credentials in code
 })
 
 const chatCompletion = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary
- add GOOBLA_TLS_CERT/KEY env vars
- validate environment settings on startup
- serve HTTPS when TLS vars are present
- lock cache writes with file locks
- update docs for profiling, TLS, and placeholder API key

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866ccb622bc8332a7d83ce51dbe595f