### PR TITLE
Improve install verification instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ curl -fsSL https://goobla.com/install.sh | sh
 ```
 > [!WARNING]
 > Inspect the script or verify its checksum before running. You can download the script from [install.sh](https://github.com/goobla/goobla/blob/main/scripts/install.sh) to review it first.
+> To check the checksum locally:
+> ```shell
+> curl -fsSL https://goobla.com/install.sh -o install.sh
+> sha256sum install.sh
+> ```
+> Compare the output against the value published on the releases page before running `sh install.sh`.
 
 [Manual install instructions](https://github.com/goobla/goobla/blob/main/docs/linux.md)
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -9,6 +9,12 @@ curl -fsSL https://goobla.com/install.sh | sh
 ```
 > [!WARNING]
 > Review the install script or verify its checksum before running. You can download the script from [install.sh](https://github.com/goobla/goobla/blob/main/scripts/install.sh) to inspect it first.
+> Verify the checksum locally with:
+> ```shell
+> curl -fsSL https://goobla.com/install.sh -o install.sh
+> sha256sum install.sh
+> ```
+> Compare the checksum with the value on the releases page before running `sh install.sh`.
 
 ## Manual install
 


### PR DESCRIPTION
## Summary
- document how to verify the `install.sh` script checksum in the README
- add equivalent instructions to `docs/linux.md`

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68702559a8048332ba9678cb9b1a9210